### PR TITLE
Add support for recurring events

### DIFF
--- a/src/Freq.php
+++ b/src/Freq.php
@@ -117,6 +117,8 @@ class Freq
     public function getAllOccurrences()
     {
         if (empty($this->cache)) {
+            $cache = array();
+
             //build cache
             $next = $this->firstOccurrence();
             while ($next) {

--- a/src/Freq.php
+++ b/src/Freq.php
@@ -1,0 +1,596 @@
+<?php
+namespace om;
+/**
+ * Class taken from https://github.com/coopTilleuls/intouch-iCalendar.git (Freq.php)
+ * @author PC Drew <pc@schoolblocks.com>
+ */
+
+/**
+ * A class to store Frequency-rules in. Will allow a easy way to find the
+ * last and next occurrence of the rule.
+ *
+ * No - this is so not pretty. But.. ehh.. You do it better, and I will
+ * gladly accept patches.
+ *
+ * Created by trail-and-error on the examples given in the RFC.
+ *
+ * TODO: Update to a better way of doing calculating the different options.
+ * Instead of only keeping track of the best of the current dates found
+ * it should instead keep a array of all the calculated dates within the
+ * period.
+ * This should fix the issues with multi-rule + multi-rule interference,
+ * and make it possible to implement the SETPOS rule.
+ * By pushing the next period onto the stack as the last option will
+ * (hopefully) remove the need for the awful simpleMode
+ *
+ * @author Morten Fangel (C) 2008
+ * @author Michael Kahn (C) 2013
+ * @license http://creativecommons.org/licenses/by-sa/2.5/dk/deed.en_GB CC-BY-SA-DK
+ */
+class Freq
+{
+    protected $weekdays = array('MO'=>'monday', 'TU'=>'tuesday', 'WE'=>'wednesday', 'TH'=>'thursday', 'FR'=>'friday', 'SA'=>'saturday', 'SU'=>'sunday');
+    protected $knownRules = array('month', 'weekno', 'day', 'monthday', 'yearday', 'hour', 'minute'); //others : 'setpos', 'second'
+    protected $ruleModifiers = array('wkst');
+    protected $simpleMode = true;
+
+    protected $rules = array('freq'=>'yearly', 'interval'=>1);
+    protected $start = 0;
+    protected $freq = '';
+
+    protected $excluded; //EXDATE
+    protected $added;    //RDATE
+
+    protected $cache; // getAllOccurrences()
+
+    /**
+     * Constructs a new Freqency-rule
+     * @param $rule string
+     * @param $start int Unix-timestamp (important : Need to be the start of Event)
+     * @param $excluded array of int (timestamps), see EXDATE documentation
+     * @param $added array of int (timestamps), see RDATE documentation
+     */
+    public function __construct( $rule, $start, $excluded=array(), $added=array())
+    {
+        $this->start = $start;
+        $this->excluded = array();
+
+        $rules = array();
+        foreach ( $rule AS $k => $v) {
+            $this->rules[ strtolower($k) ] = $v;
+        }
+
+        if ( isset($this->rules['until']) && is_string($this->rules['until']) ) {
+            $this->rules['until'] = strtotime($this->rules['until']);
+        } else if ($this->rules['until'] instanceof \DateTime) {
+            $this->rules['until'] = $this->rules['until']->getTimestamp();
+        }
+        $this->freq = strtolower($this->rules['freq']);
+
+        foreach ($this->knownRules AS $rule) {
+            if ( isset($this->rules['by' . $rule]) ) {
+                if ( $this->isPrerule($rule, $this->freq) ) {
+                    $this->simpleMode = false;
+                }
+            }
+        }
+
+        if (!$this->simpleMode) {
+            if (! (isset($this->rules['byday']) || isset($this->rules['bymonthday']) || isset($this->rules['byyearday']))) {
+                $this->rules['bymonthday'] = date('d', $this->start);
+            }
+        }
+
+        //set until, and cache
+        if ( isset($this->rules['count']) ) {
+
+            $cache[$ts] = $ts = $this->start;
+            for ($n=1; $n < $this->rules['count']; $n++) {
+                $ts = $this->findNext($ts);
+                $cache[$ts] = $ts;
+            }
+            $this->rules['until'] = $ts;
+
+            //EXDATE
+            if (!empty($excluded)) {
+                foreach ($excluded as $ts) {
+                    unset($cache[$ts]);
+                }
+            }
+            //RDATE
+            if (!empty($added)) {
+                $cache = $cache + $added;
+                asort($cache);
+            }
+
+            $this->cache = array_values($cache);
+        }
+
+        $this->excluded = $excluded;
+        $this->added = $added;
+    }
+
+    /**
+     * Returns all timestamps array(), build the cache if not made before
+     * @return array
+     */
+    public function getAllOccurrences()
+    {
+        if (empty($this->cache)) {
+            //build cache
+            $next = $this->firstOccurrence();
+            while ($next) {
+                $cache[] = $next;
+                $next = $this->findNext($next);
+            }
+            if (!empty($this->added)) {
+                $cache = $cache + $this->added;
+                asort($cache);
+            }
+            $this->cache = $cache;
+        }
+
+        return $this->cache;
+    }
+
+    /**
+     * Returns the previous (most recent) occurrence of the rule from the
+     * given offset
+     * @param  int $offset
+     * @return int
+     */
+    public function previousOccurrence( $offset )
+    {
+        if (!empty($this->cache)) {
+            $t2=$this->start;
+            foreach ($this->cache as $ts) {
+                if ($ts >= $offset)
+                    return $t2;
+                $t2 = $ts;
+            }
+        } else {
+            $ts = $this->start;
+            while ( ($t2 = $this->findNext($ts)) < $offset) {
+                if ($t2 == false) {
+                    break;
+                }
+                $ts = $t2;
+            }
+        }
+
+        return $ts;
+    }
+
+    /**
+     * Returns the next occurrence of this rule after the given offset
+     * @param  int $offset
+     * @return int
+     */
+    public function nextOccurrence( $offset )
+    {
+        if ($offset < $this->start)
+            return $this->firstOccurrence();
+        return $this->findNext($offset);
+    }
+
+    /**
+     * Finds the first occurrence of the rule.
+     * @return int timestamp
+     */
+    public function firstOccurrence()
+    {
+        $t = $this->start;
+        if (in_array($t, $this->excluded))
+            $t = $this->findNext($t);
+
+        return $t;
+    }
+
+    /**
+     * Finds the absolute last occurrence of the rule from the given offset.
+     * Builds also the cache, if not set before...
+     * @return int timestamp
+     */
+    public function lastOccurrence()
+    {
+        //build cache if not done
+        $this->getAllOccurrences();
+        //return last timestamp in cache
+        return end($this->cache);
+    }
+
+    /**
+     * Calculates the next time after the given offset that the rule
+     * will apply.
+     *
+     * The approach to finding the next is as follows:
+     * First we establish a timeframe to find timestamps in. This is
+     * between $offset and the end of the period that $offset is in.
+     *
+     * We then loop though all the rules (that is a Prerule in the
+     * current freq.), and finds the smallest timestamp inside the
+     * timeframe.
+     *
+     * If we find something, we check if the date is a valid recurrence
+     * (with validDate). If it is, we return it. Otherwise we try to
+     * find a new date inside the same timeframe (but using the new-
+     * found date as offset)
+     *
+     * If no new timestamps were found in the period, we try in the
+     * next period
+     *
+     * @param  int $offset
+     * @return int
+     */
+    public function findNext($offset)
+    {
+        if (!empty($this->cache)) {
+            foreach ($this->cache as $ts) {
+                if ($ts > $offset)
+                    return $ts;
+            }
+        }
+
+        $debug = false;
+
+        //make sure the offset is valid
+        if ( $offset === false || (isset($this->rules['until']) && $offset > $this->rules['until']) ) {
+            if($debug) echo 'STOP: ' . date('r', $offset) . "\n";
+
+            return false;
+        }
+
+        $found = true;
+
+        //set the timestamp of the offset (ignoring hours and minutes unless we want them to be
+        //part of the calculations.
+        if($debug) echo 'O: ' . date('r', $offset) . "\n";
+        $hour = (in_array($this->freq, array('hourly','minutely')) && $offset > $this->start) ? date('H', $offset) : date('H', $this->start);
+        $minute = (($this->freq == 'minutely' || isset($this->rules['byminute'])) && $offset > $this->start) ? date('i', $offset) : date('i', $this->start);
+        $t = mktime($hour, $minute, date('s', $this->start), date('m', $offset), date('d', $offset), date('Y',$offset));
+        if($debug) echo 'START: ' . date('r', $t) . "\n";
+
+        if ($this->simpleMode) {
+            if ($offset < $t) {
+                $ts = $t;
+                if ($ts && in_array($ts, $this->excluded))
+                    $ts = $this->findNext($ts);
+            } else {
+                $ts = $this->findStartingPoint( $t, $this->rules['interval'], false );
+                if ( !$this->validDate( $ts ) ) {
+                    $ts = $this->findNext($ts);
+                }
+            }
+
+            return $ts;
+        }
+
+        $eop = $this->findEndOfPeriod($offset);
+        if($debug) echo 'EOP: ' . date('r', $eop) . "\n";
+
+        foreach ($this->knownRules AS $rule) {
+            if ( $found && isset($this->rules['by' . $rule]) ) {
+                if ( $this->isPrerule($rule, $this->freq) ) {
+                    $subrules = explode(',', $this->rules['by' . $rule]);
+                    $_t = null;
+                    foreach ($subrules AS $subrule) {
+                        $imm = call_user_func_array(array($this, 'ruleBy' . $rule), array($subrule, $t));
+                        if ($imm === false) {
+                            break;
+                        }
+                        if($debug) echo strtoupper($rule) . ': ' . date('r', $imm) . ' A: ' . ((int) ($imm > $offset && $imm < $eop)) . "\n";
+                        if ( $imm > $offset && $imm < $eop && ($_t == null || $imm < $_t) ) {
+                            $_t = $imm;
+                        }
+                    }
+                    if ($_t !== null) {
+                        $t = $_t;
+                    } else {
+                        $found = $this->validDate($t);
+                    }
+                }
+            }
+        }
+
+        if ($offset < $this->start && $this->start < $t) {
+            $ts = $this->start;
+        } elseif ( $found && ($t != $offset)) {
+            if ( $this->validDate( $t ) ) {
+                if($debug) echo 'OK' . "\n";
+                $ts = $t;
+            } else {
+                if($debug) echo 'Invalid' . "\n";
+                $ts = $this->findNext($t);
+            }
+        } else {
+            if($debug) echo 'Not found' . "\n";
+            $ts = $this->findNext( $this->findStartingPoint( $offset, $this->rules['interval'] ) );
+        }
+        if ($ts && in_array($ts, $this->excluded))
+            return $this->findNext($ts);
+
+        return $ts;
+    }
+
+    /**
+     * Finds the starting point for the next rule. It goes $interval
+     * 'freq' forward in time since the given offset
+     * @param  int     $offset
+     * @param  int     $interval
+     * @param  boolean $truncate
+     * @return int
+     */
+    private function findStartingPoint( $offset, $interval, $truncate = true )
+    {
+        $_freq = ($this->freq == 'daily') ? 'day__' : $this->freq;
+        $t = '+' . $interval . ' ' . substr($_freq,0,-2) . 's';
+        if ($_freq == 'monthly' && $truncate) {
+            if ($interval > 1) {
+                $offset = strtotime('+' . ($interval - 1) . ' months ', $offset);
+            }
+            $t = '+' . (date('t', $offset) - date('d', $offset) + 1) . ' days';
+        }
+
+        $sp = strtotime($t, $offset);
+
+        if ($truncate) {
+            $sp = $this->truncateToPeriod($sp, $this->freq);
+        }
+
+        return $sp;
+    }
+
+    /**
+     * Finds the earliest timestamp posible outside this perioid
+     * @param  int $offset
+     * @return int
+     */
+    public function findEndOfPeriod($offset)
+    {
+        return $this->findStartingPoint($offset, 1);
+    }
+
+    /**
+     * Resets the timestamp to the beginning of the
+     * period specified by freq
+     *
+     * Yes - the fall-through is on purpose!
+     *
+     * @param  int $time
+     * @param  int $freq
+     * @return int
+     */
+    private function truncateToPeriod( $time, $freq )
+    {
+        $date = getdate($time);
+        switch ($freq) {
+            case "yearly":
+                $date['mon'] = 1;
+            case "monthly":
+                $date['mday'] = 1;
+            case "daily":
+                $date['hours'] = 0;
+            case 'hourly':
+                $date['minutes'] = 0;
+            case "minutely":
+                $date['seconds'] = 0;
+                break;
+            case "weekly":
+                if ( date('N', $time) == 1) {
+                    $date['hours'] = 0;
+                    $date['minutes'] = 0;
+                    $date['seconds'] = 0;
+                } else {
+                    $date = getdate(strtotime("last monday 0:00", $time));
+                }
+                break;
+        }
+        $d = mktime($date['hours'], $date['minutes'], $date['seconds'], $date['mon'], $date['mday'], $date['year']);
+
+        return $d;
+    }
+
+    /**
+     * Applies the BYDAY rule to the given timestamp
+     * @param  string $rule
+     * @param  int    $t
+     * @return int
+     */
+    private function ruleByday($rule, $t)
+    {
+        $dir = ($rule{0} == '-') ? -1 : 1;
+        $dir_t = ($dir == 1) ? 'next' : 'last';
+
+        $d = $this->weekdays[substr($rule,-2)];
+        $s = $dir_t . ' ' . $d . ' ' . date('H:i:s',$t);
+
+        if ( $rule == substr($rule, -2) ) {
+            if ( date('l', $t) == ucfirst($d) ) {
+                $s = 'today ' . date('H:i:s',$t);
+            }
+
+            $_t = strtotime($s, $t);
+
+            if ( $_t == $t && in_array($this->freq, array('monthly', 'yearly')) ) {
+                // Yes. This is not a great idea.. but hey, it works.. for now
+                $s = 'next ' . $d . ' ' . date('H:i:s',$t);
+                $_t = strtotime($s, $_t);
+            }
+
+            return $_t;
+        } else {
+            $_f = $this->freq;
+            if ( isset($this->rules['bymonth']) && $this->freq == 'yearly' ) {
+                $this->freq = 'monthly';
+            }
+            if ($dir == -1) {
+                $_t = $this->findEndOfPeriod($t);
+            } else {
+                $_t = $this->truncateToPeriod($t, $this->freq);
+            }
+            $this->freq = $_f;
+
+            $c = preg_replace('/[^0-9]/','',$rule);
+            $c = ($c == '') ? 1 : $c;
+
+            $n = $_t;
+            while ($c > 0) {
+                if ( $dir == 1 && $c == 1 && date('l', $t) == ucfirst($d) ) {
+                    $s = 'today ' . date('H:i:s',$t);
+                }
+                $n = strtotime($s, $n);
+                $c--;
+            }
+
+            return $n;
+        }
+    }
+
+    private function ruleBymonth($rule, $t)
+    {
+        $_t = mktime(date('H',$t), date('i',$t), date('s',$t), $rule, date('d', $t), date('Y', $t));
+        if ( $t == $_t && isset($this->rules['byday']) ) {
+            // TODO: this should check if one of the by*day's exists, and have a multi-day value
+            return false;
+        } else {
+            return $_t;
+        }
+    }
+
+    private function ruleBymonthday($rule, $t)
+    {
+        if ($rule < 0) {
+            $rule = date('t', $t) + $rule + 1;
+        }
+
+        return mktime(date('H',$t), date('i',$t), date('s',$t), date('m', $t), $rule, date('Y', $t));
+    }
+
+    private function ruleByyearday($rule, $t)
+    {
+        if ($rule < 0) {
+            $_t = $this->findEndOfPeriod();
+            $d = '-';
+        } else {
+            $_t = $this->truncateToPeriod($t, $this->freq);
+            $d = '+';
+        }
+        $s = $d . abs($rule -1) . ' days ' . date('H:i:s',$t);
+
+        return strtotime($s, $_t);
+    }
+
+    private function ruleByweekno($rule, $t)
+    {
+        if ($rule < 0) {
+            $_t = $this->findEndOfPeriod();
+            $d = '-';
+        } else {
+            $_t = $this->truncateToPeriod($t, $this->freq);
+            $d = '+';
+        }
+
+        $sub = (date('W', $_t) == 1) ? 2 : 1;
+        $s = $d . abs($rule - $sub) . ' weeks ' . date('H:i:s',$t);
+        $_t  = strtotime($s, $_t);
+
+        return $_t;
+    }
+
+    private function ruleByhour($rule, $t)
+    {
+        $_t = mktime($rule, date('i',$t), date('s',$t), date('m',$t), date('d', $t), date('Y', $t));
+
+        return $_t;
+    }
+
+    private function ruleByminute($rule, $t)
+    {
+        $_t = mktime(date('h',$t), $rule, date('s',$t), date('m',$t), date('d', $t), date('Y', $t));
+
+        return $_t;
+    }
+
+    private function validDate( $t )
+    {
+        if ( isset($this->rules['until']) && $t > $this->rules['until'] ) {
+            return false;
+        }
+
+        if (in_array($t, $this->excluded)) {
+            return false;
+        }
+
+        if ( isset($this->rules['bymonth']) ) {
+            $months = explode(',', $this->rules['bymonth']);
+            if ( !in_array(date('m', $t), $months)) {
+                return false;
+            }
+        }
+        if ( isset($this->rules['byday']) ) {
+            $days = explode(',', $this->rules['byday']);
+            foreach ($days As $i => $k) {
+                $days[$i] = $this->weekdays[ preg_replace('/[^A-Z]/', '', $k)];
+            }
+            if ( !in_array(strtolower(date('l', $t)), $days)) {
+                return false;
+            }
+        }
+        if ( isset($this->rules['byweekno']) ) {
+            $weeks = explode(',', $this->rules['byweekno']);
+            if ( !in_array(date('W', $t), $weeks)) {
+                return false;
+            }
+        }
+        if ( isset($this->rules['bymonthday'])) {
+            $weekdays = explode(',', $this->rules['bymonthday']);
+            foreach ($weekdays As $i => $k) {
+                if ($k < 0) {
+                    $weekdays[$i] = date('t', $t) + $k + 1;
+                }
+            }
+            if ( !in_array(date('d', $t), $weekdays)) {
+                return false;
+            }
+        }
+        if ( isset($this->rules['byhour']) ) {
+            $hours = explode(',', $this->rules['byhour']);
+            if ( !in_array(date('H', $t), $hours)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function isPrerule($rule, $freq)
+    {
+        if( $rule == 'year')
+
+            return false;
+        if( $rule == 'month' && $freq == 'yearly')
+
+            return true;
+        if( $rule == 'monthday' && in_array($freq, array('yearly', 'monthly')) && !isset($this->rules['byday']))
+
+            return true;
+        // TODO: is it faster to do monthday first, and ignore day if monthday exists? - prolly by a factor of 4..
+        if( $rule == 'yearday' && $freq == 'yearly' )
+
+            return true;
+        if( $rule == 'weekno' && $freq == 'yearly' )
+
+            return true;
+        if( $rule == 'day' && in_array($freq, array('yearly', 'monthly', 'weekly')))
+
+            return true;
+        if( $rule == 'hour' && in_array($freq, array('yearly', 'monthly', 'weekly', 'daily')))
+
+            return true;
+        if( $rule == 'minute' )
+
+            return true;
+
+        return false;
+    }
+}

--- a/src/Freq.php
+++ b/src/Freq.php
@@ -99,7 +99,7 @@ class Freq
             }
             //RDATE
             if (!empty($added)) {
-                $cache = $cache + $added;
+                $cache = array_unique(array_merge(array_values($cache), $added));
                 asort($cache);
             }
 
@@ -124,7 +124,7 @@ class Freq
                 $next = $this->findNext($next);
             }
             if (!empty($this->added)) {
-                $cache = $cache + $this->added;
+                $cache = array_unique(array_merge($cache, $this->added));
                 asort($cache);
             }
             $this->cache = $cache;

--- a/src/Freq.php
+++ b/src/Freq.php
@@ -281,7 +281,7 @@ class Freq
                             break;
                         }
                         if($debug) echo strtoupper($rule) . ': ' . date('r', $imm) . ' A: ' . ((int) ($imm > $offset && $imm < $eop)) . "\n";
-                        if ( $imm > $offset && $imm < $eop && ($_t == null || $imm < $_t) ) {
+                        if ( $imm > $offset && $imm <= $eop && ($_t == null || $imm < $_t) ) {
                             $_t = $imm;
                         }
                     }

--- a/src/IcalParser.php
+++ b/src/IcalParser.php
@@ -116,6 +116,12 @@ class IcalParser {
 		'Samoa Standard Time' => 'Pacific/Apia',
 	];
 
+	protected $arrayKeyMappings = [
+		'ATTACH'=>'ATTACHMENTS',
+		'EXDATE'=>'EXDATES',
+		'RDATE'=>'RDATES',
+	];
+
 	/**
 	 * @param string $file
 	 * @param null $callback
@@ -168,13 +174,24 @@ class IcalParser {
 					$counters[$section] = isset($counters[$section]) ? $counters[$section] + 1 : 0;
 					continue 2; // while
 					break;
+				case 'END:VEVENT':
+					$section = substr($row, 4);
+					$currCounter = $counters[$section];
+					$event = $this->data[$section][$currCounter];
+					if(!empty($event['RRULE']) || !empty($event['RDATE'])) {
+						$recurrences = $this->parseRecurrences($event);
+						if(!empty($recurrences)) {
+							$this->data[$section][$currCounter]['RECURRENCES'] = $recurrences;
+						}
+					}
+					continue 2; // while
+					break;
 				case 'END:DAYLIGHT':
 				case 'END:VALARM':
 				case 'END:VTIMEZONE':
 				case 'END:VFREEBUSY':
 				case 'END:VJOURNAL':
 				case 'END:STANDARD':
-				case 'END:VEVENT':
 				case 'END:VTODO':
 				case 'END:VCALENDAR':
 					continue 2; // while
@@ -191,11 +208,12 @@ class IcalParser {
 				if ($section === 'VCALENDAR') {
 					$this->data[$key] = $value;
 				} else {
-					if($key === 'ATTACH') {
-						// use an array since there can be multiple attachments.  This does not
-						// break the current implementation--it leaves the ATTACH key alone.
-						$newKey = 'ATTACHMENTS';
-						$this->data[$section][$counters[$section]][$newKey][] = $value;
+					if(isset($this->arrayKeyMappings[$key])) {
+						// use an array since there can be multiple entries for this key.  This does not
+						// break the current implementation--it leaves the original key alone and adds
+						// a new one specifically for the array of values.
+						$arrayKey = $this->arrayKeyMappings[$key];
+						$this->data[$section][$counters[$section]][$arrayKey][] = $value;
 					}
 
 					$this->data[$section][$counters[$section]][$key] = $value;
@@ -253,7 +271,7 @@ class IcalParser {
 		}
 
 		// process simple dates with timezone
-		if ($key === 'DTSTAMP' || $key === 'LAST-MODIFIED' || $key === 'CREATED' || $key === 'DTSTART' || $key === 'DTEND') {
+		if (in_array($key, array('DTSTAMP', 'LAST-MODIFIED', 'CREATED', 'DTSTART', 'DTEND', 'EXDATE', 'RDATE'))) {
 			try {
 				$value = new \DateTime($value, ($timezone ?: $this->timezone));
 			} catch (\Exception $e) {
@@ -265,7 +283,15 @@ class IcalParser {
 			$middle = null;
 			$value = [];
 			foreach ($matches as $match) {
-				$value[$match['key']] = $match['value'];
+				if (in_array($match['key'], array('UNTIL'))) {
+					try {
+						$value[$match['key']] = new \DateTime($match['value'], ($timezone ?: $this->timezone));
+					} catch (\Exception $e) {
+						$value[$match['key']] = $match['value'];
+					}
+				} else {
+					$value[$match['key']] = $match['value'];
+				}
 			}
 		}
 
@@ -291,6 +317,47 @@ class IcalParser {
 		}
 
 		return [$key, $middle, $value];
+	}
+
+
+	public function parseRecurrences($event) {
+		$recurring = new Recurrence($event['RRULE']);
+		$excluding = array();
+		$additions = array();
+
+		if(!empty($event['EXDATES'])) {
+			foreach ($event['EXDATES'] as $exDate) {
+				$excluding[] = $exDate->getTimestamp();
+			}
+		}
+
+		if(!empty($event['RDATES'])) {
+			var_dump($event['RDATES']);
+			foreach ($event['RDATES'] as $rDate) {
+				$additions[] = $rDate->getTimestamp();
+			}
+		}
+
+		$until = $recurring->getUntil();
+		if ($until === false) {
+			//forever... limit to 3 years
+			$end = clone($event['DTSTART']);
+			$end->add(new \DateInterval('P3Y')); // + 3 years
+			$recurring->setUntil($end);
+			$until = $recurring->getUntil();
+		}
+
+		date_default_timezone_set($event['DTSTART']->getTimezone()->getName());
+		$frequency = new Freq($recurring->rrule, $event['DTSTART']->getTimestamp(), $excluding, $additions);
+		$recurrenceTimestamps = $frequency->getAllOccurrences();
+		$recurrences = array();
+		foreach($recurrenceTimestamps as $recurrenceTimestamp) {
+			$tmp = new \DateTime("now", $event['DTSTART']->getTimezone());
+			$tmp->setTimestamp($recurrenceTimestamp);
+			$recurrences[] = $tmp;
+		}
+
+		return $recurrences;
 	}
 
 	/**
@@ -345,4 +412,5 @@ class IcalParser {
 		}
 		return [];
 	}
+
 }

--- a/src/IcalParser.php
+++ b/src/IcalParser.php
@@ -398,16 +398,21 @@ class IcalParser {
 						$events[] = $event;
 					} else {
 						$recurrences = $event['RECURRENCES'];
-						unset($event['RECURRENCES']);
 						$event['RECURRING'] = true;
 						$eventInterval = $event['DTSTART']->diff($event['DTEND']);
 
+						$firstEvent = true;
 						foreach($recurrences as $recurDate) {
 							$newEvent = $event;
-							$newEvent['DTSTART'] = $recurDate;
-							$newEvent['DTEND'] = clone($recurDate);
-							$newEvent['DTEND']->add($eventInterval);
+							if(!$firstEvent) {
+								unset($event['RECURRENCES']);
+								$newEvent['DTSTART'] = $recurDate;
+								$newEvent['DTEND'] = clone($recurDate);
+								$newEvent['DTEND']->add($eventInterval);
+							}
+
 							$events[] = $newEvent;
+							$firstEvent = false;
 						}
 					}
 				}

--- a/src/Recurrence.php
+++ b/src/Recurrence.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace om;
+
+use \DateTime;
+/**
+ * Class taken from https://github.com/coopTilleuls/intouch-iCalendar.git (Recurrence.php)
+ *
+ * A wrapper for recurrence rules in iCalendar.  Parses the given line and puts the
+ * recurrence rules in the correct field of this object.
+ *
+ * See http://tools.ietf.org/html/rfc2445 for more information.  Page 39 and onward contains more
+ * information on the recurrence rules themselves.  Page 116 and onward contains
+ * some great examples which were often used for testing.
+ *
+ * @author Steven Oxley
+ * @author Michael Kahn (C) 2013
+ * @license http://creativecommons.org/licenses/by-sa/2.5/dk/deed.en_GB CC-BY-SA-DK
+ */
+class Recurrence
+{
+    public $rrule;
+    protected $freq;
+    protected $until;
+    protected $count;
+    protected $interval;
+    protected $bysecond;
+    protected $byminute;
+    protected $byhour;
+    protected $byday;
+    protected $bymonthday;
+    protected $byyearday;
+    protected $byweekno;
+    protected $bymonth;
+    protected $bysetpos;
+    protected $wkst;
+    /**
+     * A list of the properties that can have comma-separated lists for values.
+     * @var array
+     */
+    protected $listProperties = array(
+        'bysecond', 'byminute', 'byhour', 'byday', 'bymonthday',
+        'byyearday', 'byweekno', 'bymonth', 'bysetpos'
+    );
+    /**
+     * Creates an recurrence object with a passed in line.  Parses the line.
+     * @param array $rrule an om\icalparser row array which will be parsed to get the
+     * desired information.
+     */
+    public function __construct($rrule)
+    {
+        $this->parseRrule($rrule);
+    }
+    /**
+     * Parses an 'RRULE' array and sets the member variables of this object.
+     * Expects a string that looks like this:  'FREQ=WEEKLY;INTERVAL=2;BYDAY=SU,TU,WE'
+     * @param string $line the line to be parsed
+     */
+    protected function parseRrule($rrule)
+    {
+        $this->rrule = $rrule;
+        //loop through the properties in the line and set their associated
+        //member variables
+        foreach ($this->rrule as $propertyName=>$propertyValue) {
+            //need the lower-case name for setting the member variable
+            $propertyName = strtolower($propertyName);
+            //split up the list of values into an array (if it's a list)
+            if (in_array($propertyName, $this->listProperties)) {
+                $propertyValue = explode(',', $propertyValue);
+            }
+            $this->$propertyName = $propertyValue;
+        }
+    }
+    /**
+     * Set the $until member
+     * @param mixed timestamp (int) / Valid DateTime format (string)
+     */
+    public function setUntil($ts)
+    {
+        if ($ts instanceof DateTime) {
+            $dt = $ts;
+        } else if ( is_int($ts) ) {
+            $dt = new DateTime('@' . $ts);
+        } else {
+            $dt = new DateTime($ts);
+        }
+        $this->until = $dt->format('Ymd\THisO');
+        $this->rrule['until'] = $this->until;
+    }
+    /**
+     * Retrieves the desired member variable and returns it (if it's set)
+     * @param  string $member name of the member variable
+     * @return mixed  the variable value (if set), false otherwise
+     */
+    protected function getMember($member)
+    {
+        if (isset($this->$member)) {
+            return $this->$member;
+        }
+        return false;
+    }
+    /**
+     * Returns the frequency - corresponds to FREQ in RFC 2445.
+     * @return mixed string if the member has been set, false otherwise
+     */
+    public function getFreq()
+    {
+        return $this->getMember('freq');
+    }
+    /**
+     * Returns when the event will go until - corresponds to UNTIL in RFC 2445.
+     * @return mixed string if the member has been set, false otherwise
+     */
+    public function getUntil()
+    {
+        return $this->getMember('until');
+    }
+    /**
+     * Returns the count of the times the event will occur (should only appear if 'until'
+     * does not appear) - corresponds to COUNT in RFC 2445.
+     * @return mixed string if the member has been set, false otherwise
+     */
+    public function getCount()
+    {
+        return $this->getMember('count');
+    }
+    /**
+     * Returns the interval - corresponds to INTERVAL in RFC 2445.
+     * @return mixed string if the member has been set, false otherwise
+     */
+    public function getInterval()
+    {
+        return $this->getMember('interval');
+    }
+    /**
+     * Returns the bysecond part of the event - corresponds to BYSECOND in RFC 2445.
+     * @return mixed string if the member has been set, false otherwise
+     */
+    public function getBySecond()
+    {
+        return $this->getMember('bysecond');
+    }
+    /**
+     * Returns the byminute information for the event - corresponds to BYMINUTE in RFC 2445.
+     * @return mixed string if the member has been set, false otherwise
+     */
+    public function getByMinute()
+    {
+        return $this->getMember('byminute');
+    }
+    /**
+     * Corresponds to BYHOUR in RFC 2445.
+     * @return mixed string if the member has been set, false otherwise
+     */
+    public function getByHour()
+    {
+        return $this->getMember('byhour');
+    }
+    /**
+     *Corresponds to BYDAY in RFC 2445.
+     * @return mixed string if the member has been set, false otherwise
+     */
+    public function getByDay()
+    {
+        return $this->getMember('byday');
+    }
+    /**
+     * Corresponds to BYMONTHDAY in RFC 2445.
+     * @return mixed string if the member has been set, false otherwise
+     */
+    public function getByMonthDay()
+    {
+        return $this->getMember('bymonthday');
+    }
+    /**
+     * Corresponds to BYYEARDAY in RFC 2445.
+     * @return mixed string if the member has been set, false otherwise
+     */
+    public function getByYearDay()
+    {
+        return $this->getMember('byyearday');
+    }
+    /**
+     * Corresponds to BYWEEKNO in RFC 2445.
+     * @return mixed string if the member has been set, false otherwise
+     */
+    public function getByWeekNo()
+    {
+        return $this->getMember('byweekno');
+    }
+    /**
+     * Corresponds to BYMONTH in RFC 2445.
+     * @return mixed string if the member has been set, false otherwise
+     */
+    public function getByMonth()
+    {
+        return $this->getMember('bymonth');
+    }
+    /**
+     * Corresponds to BYSETPOS in RFC 2445.
+     * @return mixed string if the member has been set, false otherwise
+     */
+    public function getBySetPos()
+    {
+        return $this->getMember('bysetpos');
+    }
+    /**
+     * Corresponds to WKST in RFC 2445.
+     * @return mixed string if the member has been set, false otherwise
+     */
+    public function getWkst()
+    {
+        return $this->getMember('wkst');
+    }
+}

--- a/tests/recurring_events.phpt
+++ b/tests/recurring_events.phpt
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @author PC Drew <pc@schoolblocks.com>
+ */
+use Tester\Assert;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+\Tester\Environment::setup();
+
+$cal = new \om\IcalParser();
+
+
+$results = $cal->parseFile(__DIR__ . '/cal/recur_instances_finite.ics');
+$events = $cal->getSortedEvents();
+
+Assert::false(empty($events[0]['RECURRENCES']));
+
+// DTSTART;TZID=America/Los_Angeles:20121002T100000
+// DTEND;TZID=America/Los_Angeles:20121002T103000
+// RRULE:FREQ=MONTHLY;INTERVAL=1;BYDAY=1TU;UNTIL=20121231T100000
+$recurrences = $events[0]['RECURRENCES'];
+Assert::equal(3, sizeof($recurrences));
+Assert::equal($events[0]['DTSTART'], $recurrences[0]);
+Assert::equal('6.11.2012 10:00:00', $recurrences[1]->format('j.n.Y H:i:s'));
+Assert::equal('4.12.2012 10:00:00', $recurrences[2]->format('j.n.Y H:i:s'));
+
+$results = $cal->parseFile(__DIR__ . '/cal/recur_instances.ics');
+$events = $cal->getSortedEvents();
+
+Assert::false(empty($events[0]['RECURRENCES']));
+
+// DTSTART;TZID=America/Los_Angeles:20121002T100000
+// DTEND;TZID=America/Los_Angeles:20121002T103000
+// RRULE:FREQ=MONTHLY;INTERVAL=1;BYDAY=1TU
+// RDATE;TZID=America/Los_Angeles:20121105T100000
+// RDATE;TZID=America/Los_Angeles:20121110T100000,20121130T100000
+// EXDATE;TZID=America/Los_Angeles:20130402T100000
+// EXDATE;TZID=America/Los_Angeles:20121204T100000
+// EXDATE;TZID=America/Los_Angeles:20130205T100000
+$recurrences = $events[0]['RECURRENCES'];
+Assert::equal(3, sizeof($recurrences));
+
+Assert: true(false);

--- a/tests/recurring_events.phpt
+++ b/tests/recurring_events.phpt
@@ -28,6 +28,14 @@ Assert::equal('6.11.2012 10:00:00', $recurrences[2]->format('j.n.Y H:i:s'));
 Assert::equal('10.11.2012 10:00:00', $recurrences[3]->format('j.n.Y H:i:s'));
 Assert::equal('4.12.2012 10:00:00', $recurrences[4]->format('j.n.Y H:i:s'));
 
+$eventsWithRecurring = $cal->getSortedEvents(true);
+Assert::equal(5, sizeof($eventsWithRecurring));
+Assert::equal($eventsWithRecurring[0]['DTSTART'], $recurrences[0]);
+Assert::equal($eventsWithRecurring[1]['DTSTART'], $recurrences[1]);
+Assert::equal($eventsWithRecurring[2]['DTSTART'], $recurrences[2]);
+Assert::equal($eventsWithRecurring[3]['DTSTART'], $recurrences[3]);
+Assert::equal($eventsWithRecurring[4]['DTSTART'], $recurrences[4]);
+
 $results = $cal->parseFile(__DIR__ . '/cal/recur_instances.ics');
 $events = $cal->getSortedEvents();
 

--- a/tests/recurring_events.phpt
+++ b/tests/recurring_events.phpt
@@ -18,11 +18,15 @@ Assert::false(empty($events[0]['RECURRENCES']));
 // DTSTART;TZID=America/Los_Angeles:20121002T100000
 // DTEND;TZID=America/Los_Angeles:20121002T103000
 // RRULE:FREQ=MONTHLY;INTERVAL=1;BYDAY=1TU;UNTIL=20121231T100000
+// RDATE;TZID=America/Los_Angeles:20121110T100000
+// RDATE;TZID=America/Los_Angeles:20121105T100000
 $recurrences = $events[0]['RECURRENCES'];
-Assert::equal(3, sizeof($recurrences));
+Assert::equal(5, sizeof($recurrences));
 Assert::equal($events[0]['DTSTART'], $recurrences[0]);
-Assert::equal('6.11.2012 10:00:00', $recurrences[1]->format('j.n.Y H:i:s'));
-Assert::equal('4.12.2012 10:00:00', $recurrences[2]->format('j.n.Y H:i:s'));
+Assert::equal('5.11.2012 10:00:00', $recurrences[1]->format('j.n.Y H:i:s'));
+Assert::equal('6.11.2012 10:00:00', $recurrences[2]->format('j.n.Y H:i:s'));
+Assert::equal('10.11.2012 10:00:00', $recurrences[3]->format('j.n.Y H:i:s'));
+Assert::equal('4.12.2012 10:00:00', $recurrences[4]->format('j.n.Y H:i:s'));
 
 $results = $cal->parseFile(__DIR__ . '/cal/recur_instances.ics');
 $events = $cal->getSortedEvents();
@@ -37,7 +41,47 @@ Assert::false(empty($events[0]['RECURRENCES']));
 // EXDATE;TZID=America/Los_Angeles:20130402T100000
 // EXDATE;TZID=America/Los_Angeles:20121204T100000
 // EXDATE;TZID=America/Los_Angeles:20130205T100000
+// total = 36 events - 3 exclusions + 3 additions
+//      because there is no "UNTIL", we only calculate the next 3 years of repeating events
 $recurrences = $events[0]['RECURRENCES'];
-Assert::equal(3, sizeof($recurrences));
+Assert::equal(36, sizeof($recurrences));
+Assert::equal($events[0]['DTSTART'], $recurrences[0]);
+Assert::equal('05.11.2012 10:00:00', $recurrences[1]->format('d.m.Y H:i:s'));
+Assert::equal('06.11.2012 10:00:00', $recurrences[2]->format('d.m.Y H:i:s'));
+Assert::equal('10.11.2012 10:00:00', $recurrences[3]->format('d.m.Y H:i:s'));
+Assert::equal('30.11.2012 10:00:00', $recurrences[4]->format('d.m.Y H:i:s'));
+Assert::equal('01.01.2013 10:00:00', $recurrences[5]->format('d.m.Y H:i:s'));
+Assert::equal('05.03.2013 10:00:00', $recurrences[6]->format('d.m.Y H:i:s'));
+Assert::equal('07.05.2013 10:00:00', $recurrences[7]->format('d.m.Y H:i:s'));
+Assert::equal('04.06.2013 10:00:00', $recurrences[8]->format('d.m.Y H:i:s'));
+Assert::equal('02.07.2013 10:00:00', $recurrences[9]->format('d.m.Y H:i:s'));
+Assert::equal('06.08.2013 10:00:00', $recurrences[10]->format('d.m.Y H:i:s'));
+Assert::equal('03.09.2013 10:00:00', $recurrences[11]->format('d.m.Y H:i:s'));
+Assert::equal('01.10.2013 10:00:00', $recurrences[12]->format('d.m.Y H:i:s'));
+Assert::equal('05.11.2013 10:00:00', $recurrences[13]->format('d.m.Y H:i:s'));
+Assert::equal('03.12.2013 10:00:00', $recurrences[14]->format('d.m.Y H:i:s'));
+Assert::equal('07.01.2014 10:00:00', $recurrences[15]->format('d.m.Y H:i:s'));
+Assert::equal('04.02.2014 10:00:00', $recurrences[16]->format('d.m.Y H:i:s'));
+Assert::equal('04.03.2014 10:00:00', $recurrences[17]->format('d.m.Y H:i:s'));
+Assert::equal('01.04.2014 10:00:00', $recurrences[18]->format('d.m.Y H:i:s'));
+Assert::equal('06.05.2014 10:00:00', $recurrences[19]->format('d.m.Y H:i:s'));
+Assert::equal('03.06.2014 10:00:00', $recurrences[20]->format('d.m.Y H:i:s'));
+Assert::equal('01.07.2014 10:00:00', $recurrences[21]->format('d.m.Y H:i:s'));
+Assert::equal('05.08.2014 10:00:00', $recurrences[22]->format('d.m.Y H:i:s'));
+Assert::equal('02.09.2014 10:00:00', $recurrences[23]->format('d.m.Y H:i:s'));
+Assert::equal('07.10.2014 10:00:00', $recurrences[24]->format('d.m.Y H:i:s'));
+Assert::equal('04.11.2014 10:00:00', $recurrences[25]->format('d.m.Y H:i:s'));
+Assert::equal('02.12.2014 10:00:00', $recurrences[26]->format('d.m.Y H:i:s'));
+Assert::equal('06.01.2015 10:00:00', $recurrences[27]->format('d.m.Y H:i:s'));
+Assert::equal('03.02.2015 10:00:00', $recurrences[28]->format('d.m.Y H:i:s'));
+Assert::equal('03.03.2015 10:00:00', $recurrences[29]->format('d.m.Y H:i:s'));
+Assert::equal('07.04.2015 10:00:00', $recurrences[30]->format('d.m.Y H:i:s'));
+Assert::equal('05.05.2015 10:00:00', $recurrences[31]->format('d.m.Y H:i:s'));
+Assert::equal('02.06.2015 10:00:00', $recurrences[32]->format('d.m.Y H:i:s'));
+Assert::equal('07.07.2015 10:00:00', $recurrences[33]->format('d.m.Y H:i:s'));
+Assert::equal('04.08.2015 10:00:00', $recurrences[34]->format('d.m.Y H:i:s'));
+Assert::equal('01.09.2015 10:00:00', $recurrences[35]->format('d.m.Y H:i:s'));
 
-Assert: true(false);
+foreach($events[0]['EXDATES'] as $exDate) {
+    Assert::notContains($exDate, $recurrences);
+}


### PR DESCRIPTION
Added/improved the following areas.  Tests have been created and are all passing.

+ Recurring events (parsing a single RRULE entry and multiple EXDATE or RDATE entries has been added.  If a VEVENT includes an RRULE entry, the set of recurring start date/times are stored in the RECURRENCES array key of the event.  Most of the recurring code was taken from https://github.com/coopTilleuls/intouch-iCalendar, although bugs were fixed in that code as well.

+ Modified how ATTACHMENTS (previous pull request) is handled to handle more entries that can duplicate (like EXDATE and RDATE).  Multiple EXDATE and RDATE entries are saved in EXDATES and RDATES.  Multiple ATTACH entries are still saved in ATTACHMENTS.

+ getEvents() function call will optionally return all recurrences as individual events (with all the same values as the original event--no attempt to modify UIDs or anything else).  The default is still the current behavior: getEvents(false) which does not return all recurrences, just the recurrence information as an attribute of each event.  Calling: getEvents(true) will return all recurrences.