### PR TITLE
Fix quoted printable encoding

### DIFF
--- a/src/IcalParser.php
+++ b/src/IcalParser.php
@@ -265,6 +265,10 @@ class IcalParser {
 						} catch (\Exception $e) {
 							$middle[$match['key']] = $match['value'];
 						}
+					} else if ($match['key'] === 'ENCODING') {
+						if ($match['value'] === 'QUOTED-PRINTABLE'){
+							$value = quoted_printable_decode($value);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
There are ical-files like:

DESCRIPTION;CHARSET=utf-8;ENCODING=QUOTED-PRINTABLE: some quoted printable text

Add code to decode this correctly.