### PR TITLE
#41 Misnamed method getTimezone

### DIFF
--- a/src/IcalParser.php
+++ b/src/IcalParser.php
@@ -435,6 +435,13 @@ class IcalParser {
 	public function getTimezones() {
 		return isset($this->data['VTIMEZONE']) ? $this->data['VTIMEZONE'] : [];
 	}
+	
+	/**
+	 * @return array
+	 */
+	public function getTimezone() {
+		return $this->getTimezones();
+	}
 
 	/**
 	 * Return sorted event list as array


### PR DESCRIPTION
#41 Add an alias method that points getTimezone to getTimezones.
Using an alias fixes this without breaking someone or somewhere that may point at the other method.