### PR TITLE
fix invalid param

### DIFF
--- a/src/Freq.php
+++ b/src/Freq.php
@@ -404,7 +404,7 @@ class Freq {
 	 * @param int $offset
 	 * @return int
 	 */
-	public function findEndOfPeriod($offset) {
+	public function findEndOfPeriod($offset = 0) {
 		return $this->findStartingPoint($offset, 1, false);
 	}
 

--- a/tests/recurring_events.phpt
+++ b/tests/recurring_events.phpt
@@ -88,7 +88,7 @@ foreach ($events[0]['EXDATES'] as $exDate) {
 
 
 $results = $cal->parseFile(__DIR__ . '/cal/recur_instances_with_modifications.ics');
-$events = $cal->getSortedEvents(true);
+$events = $cal->getSortedEvents();
 
 Assert::false(empty($events[0]['RECURRENCES']));
 // the 12th entry is the modified event, related to the remaining recurring events
@@ -136,7 +136,7 @@ usort($trueEvents, function ($a, $b) {
 	return $a['DTSTART'] > $b['DTSTART'];
 });
 
-$events = $cal->getSortedEvents(true);
+$events = $cal->getSortedEvents();
 Assert::false(empty($events[0]['RECURRENCES']));
 Assert::equal(count($trueEvents), count($events));
 foreach($trueEvents as $index => $trueEvent) {


### PR DESCRIPTION
Method call is provided 1 parameters, but the method signature uses 0 parameters