### PR TITLE
Fix ci & prepare php 8.0

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -14,6 +14,11 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+
       - name: Validate composer.json and composer.lock
         run: composer validate
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		}
 	],
 	"require": {
-		"php": ">=7.1.0"
+		"php": ">=7.2.0"
 	},
 	"suggest": {
 		"ext-dom": "for timezone tool"

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ foreach ($cal->getSortedEvents() as $r) {
 
 ## Requirements
 
-- PHP 7.1+
+- PHP 7.2+
 
 ## Run tests
 

--- a/src/IcalParser.php
+++ b/src/IcalParser.php
@@ -379,9 +379,10 @@ class IcalParser {
 	public function getSortedEvents(): array {
 		if ($events = $this->getEvents()) {
 			usort(
-				$events, function ($a, $b) {
-				return $a['DTSTART'] > $b['DTSTART'];
-			}
+				$events,
+				static function ($a, $b): int {
+					return ($a['DTSTART'] > $b['DTSTART']) ? 1 : -1;
+				}
 			);
 			return $events;
 		}
@@ -467,9 +468,10 @@ class IcalParser {
 	public function getReverseSortedEvents(): array {
 		if ($events = $this->getEvents()) {
 			usort(
-				$events, function ($a, $b) {
-				return $a['DTSTART'] < $b['DTSTART'];
-			}
+				$events,
+				static function ($a, $b): int {
+					return ($a['DTSTART'] < $b['DTSTART']) ? 1 : -1;
+				}
 			);
 			return $events;
 		}

--- a/tests/recurring_events.phpt
+++ b/tests/recurring_events.phpt
@@ -134,9 +134,10 @@ foreach ($results['VEVENT'] as $event) {
 }
 
 usort(
-	$trueEvents, function ($a, $b) {
-	return $a['DTSTART'] > $b['DTSTART'];
-}
+	$trueEvents,
+	static function ($a, $b): int {
+		return ($a['DTSTART'] > $b['DTSTART']) ? 1 : -1;
+	}
 );
 
 $events = $cal->getSortedEvents();


### PR DESCRIPTION
My previous pr #48 was incomplete, so the test was not done with different php versions. Now fixed.
Changed min php version to 7.2 because 7.1 is eol.
Changed return type for usort to avoid php 8.0 warning.

Best