### PR TITLE
Multiple ATTENDEE support incl. attendee parameters

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,3 @@ composer update
 composer test
 ```
 
-## TODO
-
-- add ATTENDEE support https://www.kanzaki.com/docs/ical/attendee.html

--- a/src/IcalParser.php
+++ b/src/IcalParser.php
@@ -158,6 +158,9 @@ class IcalParser {
 						}
 
 					} else {
+						if($key === 'ATTENDEE'){
+							$value = $value['VALUE'];		// backwards compatibility (leaves ATTENDEE entry as it was)
+						}
 						$this->data[$section][$this->counters[$section]][$key] = $value;
 					}
 
@@ -273,6 +276,8 @@ class IcalParser {
 						if ($match['value'] === 'QUOTED-PRINTABLE') {
 							$value = quoted_printable_decode($value);
 						}
+					} else {
+						$middle[$match['key']] = $match['value'];
 					}
 				}
 			}
@@ -332,6 +337,10 @@ class IcalParser {
 				$value = strtr($value, ['\\\\' => '\\', '\\N' => "\n", '\\n' => "\n", '\\;' => ';', '\\,' => ',']);
 			}
 		}
+		
+		if($key === 'ATTENDEE'){
+			$value = array_merge(is_array($middle) ? $middle : ['middle' => $middle], ['VALUE' => $value]);
+		}
 
 		return [$key, $middle, $value];
 	}
@@ -347,7 +356,7 @@ class IcalParser {
 	}
 
 	public function isMultipleKey(string $key): ?string {
-		return (['ATTACH' => 'ATTACHMENTS', 'EXDATE' => 'EXDATES', 'RDATE' => 'RDATES'])[$key] ?? null;
+		return (['ATTACH' => 'ATTACHMENTS', 'EXDATE' => 'EXDATES', 'RDATE' => 'RDATES', 'ATTENDEE' => 'ATTENDEES'])[$key] ?? null;
 	}
 
 	/**


### PR DESCRIPTION
Added the key `ATTENDEES` which contains potentially multiple attendees with their value and all of the attendee parameters (called `$middle` in the code). The scheme looks like this:
```php
[
  // ...
  'ATTENDEE' => 'mailto:test@example.org',
  'ATTENDEES' => [
    [
      'ROLE' => 'REQ-PARTICIPANT',
      'PARTSTAT' => 'NEEDS-ACTION',
      'CN' => 'John Doe',
      'VALUE' => 'mailto:john.doe@example.org'
    ],
    [
      'ROLE' => 'REQ-PARTICIPANT',
      'PARTSTAT' => 'NEEDS-ACTION',
      'CN' => 'Test Example',
      'VALUE' => 'mailto:test@example.org'
    ]
  ],
  // ...
]
```
The value of the ATTENDEE property is added as `VALUE` in each of the entries in `ATTENDEES`.

This change should be backwards compatible because it does not touch the `ATTENDEE` key.