### PR TITLE
Extract CN parameter of ORGANIZER

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,28 @@ foreach ($cal->getEvents()->sorted() as $event) {
 }
 ```
 
+Each property of each event is available using the property name (in capital letters) as a key. 
+There are some special cases:
+
+- multiple attendees with individual parameters: use `ATTENDEES` as key to get all attendees in the following scheme:
+```php
+[
+	[
+		'ROLE' => 'REQ-PARTICIPANT',
+		'PARTSTAT' => 'NEEDS-ACTION',
+		'CN' => 'John Doe',
+		'VALUE' => 'mailto:john.doe@example.org'
+	],
+	[
+		'ROLE' => 'REQ-PARTICIPANT',
+		'PARTSTAT' => 'NEEDS-ACTION',
+		'CN' => 'Test Example',
+		'VALUE' => 'mailto:test@example.org'
+	]
+]
+```
+- organizer's name: the *CN* parameter of the organizer property can be retrieved using the key `ORGANIZER-CN`
+
 You can run example with [PHP Built-in web server](https://www.php.net/manual/en/features.commandline.webserver.php) as follow:
 
 ```shell

--- a/src/IcalParser.php
+++ b/src/IcalParser.php
@@ -158,7 +158,12 @@ class IcalParser {
 						}
 
 					} else {
-						if($key === 'ATTENDEE'){
+						if(in_array($key, ['ORGANIZER'])){
+							foreach($middle as $midKey => $midVal){
+								$this->data[$section][$this->counters[$section]][$key.'-'.$midKey] = $midVal;
+							}
+						}
+						if(in_array($key, ['ATTENDEE', 'ORGANIZER'])){
 							$value = $value['VALUE'];		// backwards compatibility (leaves ATTENDEE entry as it was)
 						}
 						$this->data[$section][$this->counters[$section]][$key] = $value;
@@ -338,7 +343,7 @@ class IcalParser {
 			}
 		}
 		
-		if($key === 'ATTENDEE'){
+		if(in_array($key, ['ATTENDEE', 'ORGANIZER'])){
 			$value = array_merge(is_array($middle) ? $middle : ['middle' => $middle], ['VALUE' => $value]);
 		}
 


### PR DESCRIPTION
Made the CN property of the ORGANIZER attribute available as ORGANIZER-CN. Should be backwards compatible (key ORGANIZER still exists without changes). 

Added some usage information to readme.md.