### PR TITLE
Fix badge image url

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # PHP iCal Parser
 
-[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/OzzyCzech/icalparser/PHP%20Tests)](https://github.com/OzzyCzech/icalparser/actions)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/OzzyCzech/icalparser/php.yml?branch=master)](https://github.com/OzzyCzech/icalparser/actions)
 [![Latest Stable Version](https://poser.pugx.org/om/icalparser/v/stable.png)](https://packagist.org/packages/om/icalparser)
 [![Total Downloads](https://poser.pugx.org/om/icalparser/downloads.png)](https://packagist.org/packages/om/icalparser)
 [![Latest Unstable Version](https://poser.pugx.org/om/icalparser/v/unstable.png)](https://packagist.org/packages/om/icalparser)


### PR DESCRIPTION
They changed the url:
https://github.com/badges/shields/issues/8671