### PR TITLE
Update github actions/checkout@v2

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     continue-on-error: ${{ matrix.experimental }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/typo.yml
+++ b/.github/workflows/typo.yml
@@ -6,7 +6,7 @@ jobs:
     name: Check for typos / misspells
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Run misspell with reviewdog
         uses: reviewdog/action-misspell@v1


### PR DESCRIPTION
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2