### PR TITLE
Add .gitattributes to minimize dist size

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+*.php  text diff=php
+*.phpt text diff=php
+
+# Exclude non-essential files from dist to minimize package size.
+/.github/ export-ignore
+/bin/ export-ignore
+/example/ export-ignore
+/tests/ export-ignore
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/readme.md export-ignore


### PR DESCRIPTION
As recommended by composer: https://getcomposer.org/doc/02-libraries.md#light-weight-distribution-packages

Dist size of zip: 58kb -> 18kb