### PR TITLE
fix(#84): prevent timezone leakage during recurrence parsing

### DIFF
--- a/src/IcalParser.php
+++ b/src/IcalParser.php
@@ -210,7 +210,10 @@ class IcalParser {
 			$until = $recurring->getUntil();
 		}
 
-		$tzName = $event['DTSTART']->getTimezone()->getName();
+        // remember current tz
+        $default_timezone = date_default_timezone_get();
+
+        $tzName = $event['DTSTART']->getTimezone()->getName();
 		date_default_timezone_set($tzName === 'Z' ? 'UTC' : $tzName);
 		$frequency = new Freq($recurring->rrule, $event['DTSTART']->getTimestamp(), $exclusions, $additions);
 		$recurrenceTimestamps = $frequency->getAllOccurrences();
@@ -269,6 +272,9 @@ class IcalParser {
 				}
 			}
 		}
+
+		// restore previous default timezone
+		date_default_timezone_set($default_timezone);
 
 		return $recurrences;
 	}

--- a/tests/events.recurring.phpt
+++ b/tests/events.recurring.phpt
@@ -243,6 +243,32 @@ test('Two times weekly events', function () {
 	Assert::equal('29.1.2026 11:00:00', $events[8]['DTEND']->format('j.n.Y H:i:s'));
 });
 
+test('recurring ical feed does not leak timezone (issue #84', function () {
+	date_default_timezone_set('UTC');
+
+	$calendar = <<<'ICS'
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//DenverWeekly//EN
+BEGIN:VEVENT
+UID:denver-weekly@example.com
+DTSTAMP:20260601T120000Z
+SUMMARY:Saturday in Denver
+DTSTART;TZID=America/Denver:20260613T000000
+DTEND;TZID=America/Denver:20260614T000000
+RRULE:FREQ=WEEKLY;COUNT=3;BYDAY=SA
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+	$parser = new IcalParser();
+	$parser->parseString($calendar);
+	$first = $parser->getEvents()->sorted()[0]['DTSTART'];
+
+	// echoe event time in the server timezone (UTC).
+	Assert::same('0600', (clone $first)->setTimezone(new DateTimeZone(date_default_timezone_get()))->format('Hi'));
+});
+
 /**
  * https://github.com/OzzyCzech/icalparser/issues/38
  */


### PR DESCRIPTION
fixes issue #84. see added Test case for details.